### PR TITLE
docs: Fix simple typo, confrom -> conform

### DIFF
--- a/src/far-fetch.js
+++ b/src/far-fetch.js
@@ -217,7 +217,7 @@ export default class FarFetch {
   }
 
   /**
-   * Set options to confrom to FarFetch
+   * Set options to conform to FarFetch
    *
    * @private
    * @param {object} options


### PR DESCRIPTION
There is a small typo in src/far-fetch.js.

Should read `conform` rather than `confrom`.

